### PR TITLE
Add VS Code Arduino configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // Extension recommendations to support Arduino development
+    "recommendations": [
+        "vsciot-vscode.vscode-arduino", // Provides Arduino tooling and board upload support
+        "ms-vscode.cpptools" // Supplies C/C++ IntelliSense for Arduino sketches
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    // Instructs the VS Code Arduino extension to use the modern CLI backend
+    "arduino.useArduinoCli": true,
+    // Ensures VS Code can locate the arduino-cli executable
+    "arduino.commandPath": "arduino-cli",
+    // Default board definition; adjust if using a different board
+    "arduino.fqbn": "arduino:avr:uno"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+    // Task configuration enabling build and upload directly from VS Code
+    "version": "2.0.0",
+    "tasks": [
+        {
+            // Verifies the sketch using arduino-cli
+            "label": "Arduino: Verify",
+            "type": "shell",
+            "command": "arduino-cli compile --fqbn arduino:avr:uno ${workspaceFolder}/RaceBox-Wicaksu.ino",
+            "problemMatcher": ["$gcc"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            // Uploads the compiled sketch to the connected board
+            "label": "Arduino: Upload",
+            "type": "shell",
+            "command": "arduino-cli upload -p <PORT> --fqbn arduino:avr:uno ${workspaceFolder}/RaceBox-Wicaksu.ino",
+            "problemMatcher": [],
+            "group": "build"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -60,3 +60,12 @@
 
 - **TX**: GPIO 27
 - **RX**: GPIO 22
+
+## Pengembangan dengan VS Code
+
+Konfigurasi pada folder `.vscode` memungkinkan penyusunan dan pengunggahan sketch Arduino langsung dari editor.
+
+1. Saat membuka proyek ini di VS Code, instal ekstensi yang direkomendasikan agar dukungan Arduino aktif.
+2. Pastikan `arduino-cli` telah terpasang dan board `arduino:avr:uno` (atau board Anda) tersedia.
+3. Tekan `Ctrl+Shift+B` untuk menjalankan tugas **Arduino: Verify** yang akan mengompilasi `RaceBox-Wicaksu.ino`.
+4. Untuk mengunggah sketch, gunakan tugas **Arduino: Upload** dan ganti placeholder `<PORT>` pada `tasks.json` dengan port serial papan Anda.


### PR DESCRIPTION
## Summary
- add VS Code extension recommendations for Arduino development
- configure arduino-cli usage and default board
- provide build and upload tasks for verifying and flashing sketches
- document VS Code workflow in README

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno RaceBox-Wicaksu.ino` *(fails: Platform 'arduino:avr' not found; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e266979508330b9dd5efa963c512c